### PR TITLE
change targeting of stache-image for implmemenation of border

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -14,7 +14,7 @@
     text-align: center;
 }
 
-img {
+.stache-image-object {
   border: 1px solid #cccccc;
 }
 

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -14,8 +14,10 @@
     text-align: center;
 }
 
-.stache-image-object {
-  border: 1px solid #cccccc;
+.stache-image-border {
+  .stache-image-object {
+    border: 1px solid #cdcfd2;
+  }
 }
 
 .sky-tile {

--- a/src/app/content/video/index.html
+++ b/src/app/content/video/index.html
@@ -21,11 +21,13 @@
     <h4>YouTube</h4>
     <p>To find the <a href="http://www.youtube.com">YouTube</a> url to use as the video source, you need to grab the source url from within the embed code. From a video's page on Youtube, select <strong>Share</strong> and then the <strong>Embed</strong> tab. Copy the <stache-code>src=""</stache-code> url. Use this url with the Video component.
       <stache-image
+        class="stache-image-border"
         imageSource="~/assets/youtube-video.png">
       </stache-image>
       <h4>Vimeo</h4>
       <p>To find the <a href="http://www.vimeo.com">Vimeo</a> url to use as the video source, you need to grab the source url from within the embed code. From a video's page on Vimeo, select the share button and then copy the embed code. Vimeo does not enable you to select a portion. Paste the code into a text editor and copy the portion of the URL you need, starting with <stache-code>src=""</stache-code>.  </p>
-            <stache-image
+      <stache-image
+        class="stache-image-border"
         imageSource="~/assets/vimeo-video.png">
       </stache-image>
       <h4>O365</h4>


### PR DESCRIPTION
This removes the border from all images, which was affecting page anchors. Now, I'm specifically targeting stache-image-object. The border is thin enough that it's not noticeable on dark screenshots, but it's there to define a slight border between the image and the page. Most noticeable on screenshots that have a light background. For example, you can notice the border on https://host.nxt.blackbaud.com/stache/content/video. 

This style is adherent to the style guidelines I wrote up for the SKY UA guidelines. 