### PR TITLE
fix docs for custom CSS and action buttons search

### DIFF
--- a/src/app/api/components/action-buttons/action-buttons-demo.component.html
+++ b/src/app/api/components/action-buttons/action-buttons-demo.component.html
@@ -15,6 +15,11 @@
     <ul>
       <li>
         <p>
+          <stache-code>showSearch</stache-code> — (<i>Optional</i>) Specifies whether to include the search field for the action buttons. Default is true. 
+        </p>
+      </li>
+      <li>
+        <p>
           <stache-code>routes</stache-code> — Specifies the properties for each action button in the list. Each button has the following properties:
         </p>
 
@@ -57,7 +62,7 @@
         <stache-code-block
           languageType="markup">
           <stache-action-buttons
-            [routes]="routes">
+            [routes]="routes" showSearch="false">
           </stache-action-buttons>
         </stache-code-block>
       </sky-tab>

--- a/src/app/api/index.html
+++ b/src/app/api/index.html
@@ -10,7 +10,7 @@
   </stache-page-summary>
 
 
-    <stache-action-buttons [routes]="[
+    <stache-action-buttons showSearch="false" [routes]="[
         {
           name: 'Components',
           path: '/api/components',

--- a/src/app/content/action-buttons/index.html
+++ b/src/app/content/action-buttons/index.html
@@ -17,6 +17,11 @@
     <ul>
       <li>
         <p>
+          <stache-code>showSearch</stache-code> — (<i>Optional</i>) Specifies whether to include the search field for the action buttons. Default is true. 
+        </p>
+      </li>
+      <li>
+        <p>
           <stache-code>routes</stache-code> — Specifies the properties for each action button in the list. Each button has the following
           properties:
         </p>
@@ -54,7 +59,7 @@
     <sky-tabset>
       <sky-tab tabHeading="sample">
         <stache-code-block languageType="markup">
-          <stache-action-buttons [routes]="stache.jsonData.uniquefilename">
+          <stache-action-buttons [routes]="stache.jsonData.uniquefilename" showSearch="false">
           </stache-action-buttons>
         </stache-code-block>
         <p>When you use this on your site, you'll change the

--- a/src/app/learn/basics/index.html
+++ b/src/app/learn/basics/index.html
@@ -481,6 +481,11 @@ img &#123;
 
 </stache-code-block>
 </sky-tile-content-section>
+<sky-tile-content-section>
+Then, you need to tell {{ stache.jsonData.global.productNameLong }} where to find your custom CSS. From the <stache-code>src/app</stache-code> folder, open the <stache-code>app-extras.module.ts</stache-code> file. Insert this line of code at the very beginning of the file. 
+<stache-code-block>require('style-loader!./app.scss');</stache-code-block>
+
+</sky-tile-content-section>
 </sky-tile-content>
 </sky-tile>
 

--- a/src/app/support/contribute/index.html
+++ b/src/app/support/contribute/index.html
@@ -9,7 +9,7 @@
 To enhance the creation of quality techical documentation, we highly encourage contributions from all {{ stache.jsonData.global.productNameShort }} 2 users!
   </stache-page-summary>
 
-  <stache-action-buttons [routes]="[
+  <stache-action-buttons showSearch="false" [routes]="[
         {
           name: 'Submit a Request or Issue',
           path: 'https://github.com/blackbaud/stache2/issues',


### PR DESCRIPTION
Added how to call the custom CSS file from `app-extras.module.ts` on the Basics page and added the `showSearch` property to Action Buttons content and component pages.