### PR TITLE
Update site based on feedback

### DIFF
--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -61,7 +61,7 @@
               ]
             },
             {
-              "title": "Content",
+              "title": "Components",
               "route": "/content"
             },
             {

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -55,7 +55,7 @@
                   "route": "/learn/plugins"
                 },
                 {
-                  "title": "Blackbaud Procedures",
+                  "title": "Blackbaud Staff Topics",
                   "url": "https://docs.blackbaud.com/stache-internal"
                 }
               ]

--- a/src/app/content/demo-content.component.html
+++ b/src/app/content/demo-content.component.html
@@ -1,6 +1,6 @@
 <stache
   showEditButton="false"
-  pageTitle="Content"
+  pageTitle="Components"
   layout="container">
 
   <stache-page-summary>

--- a/src/app/content/search/index.html
+++ b/src/app/content/search/index.html
@@ -5,7 +5,7 @@
     Stache includes a search feature that enables users to quickly find content within a site, a group of sites, or across all search-enabled Stache sites.</p>
   </p>
   <p>
-    This feature is for internal Blackbaud use only. <a href="https://docs.blackbaud.com/stache-internal/search"><button type="button" class="sky-btn sky-btn-link-inline">Learn more <i class="fa fa-lock" aria-hidden="true" title="Blackbaud users only"></i></button></a>.
+    This feature is for internal Blackbaud use only. <a href="https://docs.blackbaud.com/stache-internal/search"><button type="button" class="sky-btn sky-btn-link-inline">Learn more <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></button></a>.
   </p>
 
 </stache>

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -15,14 +15,14 @@
   showBreadcrumbs="false"
   showEditButton="false"
   layout="container">
-  
+
   <stache-row>
     <stache-column screenSmall="12">
       <p>This is the documentation site for {{ stache.jsonData.global.productNameLong }}, a component library designed to enhance SKY UX Builder single-page applications (SPAs). For more information about SKY UX, visit their <a href="https://developer.blackbaud.com/skyux/">documentation <i class="fa fa-external-link" aria-hidden="true"></i></a>.
       </p>
     </stache-column>
   </stache-row>
-  
+
   <stache-row>
     <stache-column screenSmall="4">
       <div class="text-center">
@@ -41,7 +41,7 @@
     <stache-column screenSmall="4">
       <div class="text-center">
         <a routerLink="/content">
-          <h2 class="sky-section-heading">Content</h2>
+          <h2 class="sky-section-heading">Components</h2>
           <span class="fa-stack fa-4x">
         <i class="fa fa-square fa-stack-2x"></i>
         <i class="fa fa-picture-o fa-stack-1x fa-inverse"></i>
@@ -67,7 +67,7 @@
       </div>
     </stache-column>
   </stache-row>
-  
+
   <div class="secondary-bgd">
     <stache-row>
       <stache-column screenSmall="5">
@@ -92,9 +92,9 @@
   <br />
   <stache-row>
     <stache-column screenSmall="7">
-      <h2>Stache for Blackbaud users</h2>
+      <h2>Stache for Blackbaud staff</h2>
       <p>
-          For Blackbaud users, additional features are available to help you meet Blackbaud standards.
+          For Blackbaud staff, additional features are available to help you meet Blackbaud standards.
       </p>
         <ul>
           <li>
@@ -104,7 +104,7 @@
           </li>
           <li>
             <p>
-              To enable search for your site and include your content in the <a href="https://docs.blackbaud.com" title="Blackbaud users only">Blackbaud global search <i class="fa fa-lock" aria-hidden="true"></i></a>, we provide the Stache Search Service.
+              To enable search for your site and include your content in the <a href="https://docs.blackbaud.com" title="Blackbaud staff only">Blackbaud global search <i class="fa fa-lock" aria-hidden="true"></i></a>, we provide the Stache Search Service.
             </p>
           </li>
           <li>
@@ -122,7 +122,7 @@
     </stache-column>
     <stache-column screenSmall="5">
         <stache-image
-          imageAlt="Stache for Blackbaud users"
+          imageAlt="Stache for Blackbaud staff"
           imageSource="~/assets/consumer.jpg">
         </stache-image>
     </stache-column>

--- a/src/app/learn/basics/index.html
+++ b/src/app/learn/basics/index.html
@@ -54,7 +54,7 @@
     To provide top-level navigation within your app, you can use the <stache-code>app-nav</stache-code> component. This shared component from the SKY UX default template allows you to display a navigation bar at the top of pages.
   </p>
   <sky-alert alertType="info">
-    For <strong>internal Blackbaud SPAs</strong>, we recommend the omnibar instead of the <stache-code>app-nav</stache-code> component. However, it is for internal Blackbaud use only. To learn how to set up top-level navigation with the omnibar, see step 4 of the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">Create a Blackbaud Internal Stache SPA <i class="fa fa-lock" aria-hidden="true" title="Blackbaud users only"></i></a> tutorial.
+    For <strong>internal Blackbaud SPAs</strong>, we recommend the omnibar instead of the <stache-code>app-nav</stache-code> component. However, it is for internal Blackbaud use only. To learn how to set up top-level navigation with the omnibar, see step 4 of the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">Create a Blackbaud Internal Stache SPA <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a> tutorial.
   </sky-alert>
 
   <h3>
@@ -149,7 +149,7 @@ img &#123;
   </p>
 
   <stache-page-anchor>
-    VSTS for Blackbaud users
+    VSTS for Blackbaud staff
   </stache-page-anchor>
 
   <p>
@@ -170,7 +170,7 @@ img &#123;
     Because of these differences, each change to your repo will take, at minimum, a few minutes to release to your live SPA.
   </p>
   <p>
-    You can use tools such as VS Code to work with a local clone of your Stache site, but the web-based editor in VSTS lets you make quick changes without leaving the browser. To learn how to make changes with the VSTS web-based editor, see the <a href="https://docs.blackbaud.com/stache-internal/vsts-editor/">Edit a VSTS Stache 2 Site in Your Browser tutorial <i class="fa fa-lock" aria-hidden="true" title="Blackbaud users only"></i></a>.
+    You can use tools such as VS Code to work with a local clone of your Stache site, but the web-based editor in VSTS lets you make quick changes without leaving the browser. To learn how to make changes with the VSTS web-based editor, see the <a href="https://docs.blackbaud.com/stache-internal/vsts-editor/">Edit a VSTS Stache 2 Site in Your Browser tutorial <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a>.
   </p>
 
   <stache-page-anchor>
@@ -228,7 +228,7 @@ img &#123;
     Are you curious what a page would look like in {{ stache.jsonData.global.productNameShort }}? Here's a sample page you can copy and paste into your application. In  <stache-code>src/app/</stache-code> create a new folder with a short name. The folder name is part of the page's URL, so keep it brief and friendly. Then, create a file named <stache-code>index.html</stache-code> and paste the code below. After you save, type <stache-code>skyux serve</stache-code> to see your app, and your new page, locally.
   </p>
   <sky-alert alertType="info">
-    If you are a Blackbaud user and have your omnibar set up, don't include <stache-code escapeCharacters="true">&lt;app-nav&gt; &lt;/app-nav&gt;</stache-code> when you copy and paste.
+    If you are a Blackbaud staff member and have your omnibar set up, don't include <stache-code escapeCharacters="true">&lt;app-nav&gt; &lt;/app-nav&gt;</stache-code> when you copy and paste.
   </sky-alert>
 
 <stache-code-block>

--- a/src/app/learn/get-started/add-stache/index.html
+++ b/src/app/learn/get-started/add-stache/index.html
@@ -23,7 +23,7 @@
           npm install --save @blackbaud/stache
         </stache-code-block>
         <p>
-          If you are a Blackbaud user and plan to use the Blackbaud Identity Service authentication, install the email whitelist plugin.
+          If you are a Blackbaud staff member and plan to use the Blackbaud Identity Service authentication, install the email whitelist plugin.
         </p>
         <stache-code-block>
           npm install --save @blackbaud/skyux-builder-plugin-auth-email-whitelist

--- a/src/app/learn/get-started/clone-install/index.html
+++ b/src/app/learn/get-started/clone-install/index.html
@@ -65,7 +65,7 @@
         <ol>
           <li>
           <p>
-            From <a href="https://blackbaud.visualstudio.com/Products/_git/">VSTS Git <i class="fa fa-lock" aria-hidden="true" title="Blackbaud users only"></i></a>, select the repository dropdown and then select <strong>All repositories</strong>. To search for your repo, use the search field. Most Stache SPAs start with <stache-code>skyux-spa</stache-code>.
+            From <a href="https://blackbaud.visualstudio.com/Products/_git/">VSTS Git <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a>, select the repository dropdown and then select <strong>All repositories</strong>. To search for your repo, use the search field. Most Stache SPAs start with <stache-code>skyux-spa</stache-code>.
           </p>
               <div class="retina-screenshot">
                 <stache-image

--- a/src/app/learn/get-started/index.html
+++ b/src/app/learn/get-started/index.html
@@ -29,7 +29,7 @@
       </li>
 
       <sky-alert alertType="info">
-        Blackbaud users must also ensure they have <a href="https://docs.blackbaud.com/engineering-system-docs/learn/dev-setup-engsys/vsts-access">access to Visual Studio Team Services (VSTS) <i class="fa fa-external-link" aria-hidden="true"></i></a>.
+        Blackbaud staff must also ensure they have <a href="https://docs.blackbaud.com/engineering-system-docs/learn/dev-setup-engsys/vsts-access">access to Visual Studio Team Services (VSTS) <i class="fa fa-external-link" aria-hidden="true"></i></a>.
       </sky-alert>
     </ol>
 
@@ -49,7 +49,7 @@
  </stache-page-anchor>
 
  <p>
-   The following Git and VSTS links are available to Blackbaud users only <i class="fa fa-lock" aria-hidden="true" title="Blackbaud users only"></i>.
+   The following Git and VSTS links are available to Blackbaud staff only <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i>.
  </p>
 
   <stache-action-buttons [routes]="stache.jsonData.gitvsts" showSearch="false">

--- a/src/app/learn/get-started/new-stache/index.html
+++ b/src/app/learn/get-started/new-stache/index.html
@@ -13,7 +13,7 @@
       </p>
 
       <p>
-        <mark>Blackbaud users</mark>, follow the Blackbaud version of the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">Create a New Stache SPA <i class="fa fa-lock" aria-hidden="true" title="Blackbaud users only"></i></a> tutorial.
+        <mark>Blackbaud staff</mark>, follow the Blackbaud version of the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">Create a New Stache SPA <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a> tutorial.
       </p>
     </stache-tutorial-summary>
 
@@ -73,11 +73,11 @@
       </stache-tutorial-step-heading>
       <stache-tutorial-step-body>
         <p>
-          After you create your application, it is potentially available on the public Internet. Be careful to not allow anonymous users access to protected assets, such as user data or internal systems.
+          After you create your application and deploy to your hosted location, it is potentially available on the public Internet. Be careful to not allow anonymous users access to protected assets, such as user data or internal systems.
         </p>
-        <p>
-          If you are a Blackbaud user who did not follow the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">directions for internal SPAs <i class="fa fa-lock" aria-hidden="true" title="Blackbaud users only"></i></a>, we recommend you turn on authentication.
-        </p>
+        <sky-alert alertType="warning">
+          If you are a Blackbaud staff member who did not follow the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">directions for internal Stache SPAs <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a>, we recommend you turn on authentication.
+        </sky-alert>
         <ol>
           <li>
             <p>
@@ -164,7 +164,7 @@
           </li>
           <li>
             <p>
-              <a routerLink="/content/">{{ stache.jsonData.global.productNameShort }} Content</a> – for ways to enhance your documentation beyond basic paragraphs and headers</a>
+              <a routerLink="/content/">{{ stache.jsonData.global.productNameShort }} Components</a> – for ways to enhance your documentation beyond basic paragraphs and headers</a>
             </p>
           </li>
           <li>

--- a/src/app/learn/index.html
+++ b/src/app/learn/index.html
@@ -47,7 +47,7 @@
         name: 'Blackbaud Procedures',
         path: 'https://docs.blackbaud.com/stache-internal',
         icon: 'lock',
-        summary: 'Blackbaud users can find documentation specifically written for our internal needs.'
+        summary: 'Blackbaud staff can find documentation specifically written for our internal needs.'
       }
     ]">
   </stache-action-buttons>

--- a/src/app/learn/migrate/index.html
+++ b/src/app/learn/migrate/index.html
@@ -38,7 +38,7 @@
     Create a SPA
     </stache-page-anchor>
   <p>
-  The first step to migrate your Stache 1 site is to follow the <a routerLink="/learn/get-started">Getting Started instructions</a> to set up a new Stache site. For Blackbaud users, we strongly recommend that you follow the Blackbaud version of the <em>Create a New Stache SPA</em> tutorial.
+  The first step to migrate your Stache 1 site is to follow the <a routerLink="/learn/get-started">Getting Started instructions</a> to set up a new Stache site. For Blackbaud staff, we strongly recommend that you follow the Blackbaud version of the <em>Create a New Stache SPA</em> tutorial.
   </p>
   <h3>
     Considerations

--- a/src/app/support/changelog/index.html
+++ b/src/app/support/changelog/index.html
@@ -9,17 +9,17 @@
   </stache-page-anchor>
 
   <stache-markdown>
-- For Blackbaud users, we created a new template designed for you. Thanks to Bobby Earl for the work he did to update the [SKY UX CLI (1.2.0) <i class="fa fa-external-link" aria-hidden="true"></i>](https://github.com/blackbaud/skyux-cli/blob/master/CHANGELOG.md) to support the internal template Git URL.
-- To use the new template, Blackbaud users should follow the new <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache" title="Blackbaud users only">Create a New Stache SPA tutorial <i class="fa fa-lock" aria-hidden="true"></i></a> that we created just for you!
+- For Blackbaud staff, we created a new template designed for you. Thanks to Bobby Earl for the work he did to update the [SKY UX CLI (1.2.0) <i class="fa fa-external-link" aria-hidden="true"></i>](https://github.com/blackbaud/skyux-cli/blob/master/CHANGELOG.md) to support the internal template Git URL.
+- To use the new template, Blackbaud staff should follow the new <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache" title="Blackbaud staff users only">Create a New Stache SPA tutorial <i class="fa fa-lock" aria-hidden="true"></i></a> that we created just for you!
 - Added a tutorial for how to [migrate from Stache 1](/stache/learn/migrate).
 - Added a [Troubleshooting](/stache/support/troubleshoot) page to help you problem solve issues you may encounter.
 - Added external link icons <i class="fa fa-external-link" aria-hidden="true"></i>, to better warn you when you are leaving our website for another.
-- Added a locked icon <i class="fa fa-lock" aria-hidden="true"></i>, to show links that are restricted to Blackbaud users only.
-- Updated the [home page](/stache/) to show Blackbaud users specific benefits for you.
-- Based on feedback, made improvements to the [Getting Started](/stache/learn/get-started) documentation. For Blackbaud users, to better guide you for Stache SPAs, this also includes an improvement we made to the SKY UX App Management Portal. (Thank you, SKY UX Team!)
+- Added a locked icon <i class="fa fa-lock" aria-hidden="true"></i>, to show links that are restricted to Blackbaud staff only.
+- Updated the [home page](/stache/) to show Blackbaud staff specific benefits for you.
+- Based on feedback, made improvements to the [Getting Started](/stache/learn/get-started) documentation. For Blackbaud staff, to better guide you for Stache SPAs, this also includes an improvement we made to the SKY UX App Management Portal. (Thank you, SKY UX Team!)
 - Added a [Why Stache?](/stache/support/why-stache) page to better explain the details of Stache, including what it is, the benefits, the features, and when to use what.
 - Moved documentation (layouts, links, and navigation) from the Basics page to the [Content](/stache/content) page.
-- For Blackbaud users, we created a new Stache SPA (stache-internal) to provide *internal to Blackbaud only* documentation. This enables us to provide very specific information for you, without "mucking up" documentation that's applicable to all users. As part of this, we created a centralized location for <a href="https://docs.blackbaud.com/stache-internal/search" title="Blackbaud users only">Stache Search Service <i class="fa fa-lock" aria-hidden="true"></i></a> documentation. This means it's now available to find in the <a href="https://docs.blackbaud.com/stache-internal/search" title="Blackbaud users only">global Stache search <i class="fa fa-lock" aria-hidden="true"></i></a>
+- For Blackbaud staff, we created a new Stache SPA (stache-internal) to provide *internal to Blackbaud only* documentation. This enables us to provide very specific information for you, without "mucking up" documentation that's applicable to all users. As part of this, we created a centralized location for <a href="https://docs.blackbaud.com/stache-internal/search" title="Blackbaud staff only">Stache Search Service <i class="fa fa-lock" aria-hidden="true"></i></a> documentation. This means it's now available to find in the <a href="https://docs.blackbaud.com/stache-internal/search" title="Blackbaud staff only">global Stache search <i class="fa fa-lock" aria-hidden="true"></i></a>
   </stache-markdown>
 
 </stache>

--- a/src/app/support/index.html
+++ b/src/app/support/index.html
@@ -13,7 +13,7 @@
       </li>
       <li>
         <p>
-          <i class="fa fa-slack fa-lg" aria-hidden="true"></i> Message us in the <a href="https://blackbaud.slack.com/messages/C1R3XB8GZ" title="Blackbaud users only"> #stache-general <i class="fa fa-lock" aria-hidden="true"></i></a> Slack channel.
+          <i class="fa fa-slack fa-lg" aria-hidden="true"></i> Message us in the <a href="https://blackbaud.slack.com/messages/C1R3XB8GZ" title="Blackbaud staff only"> #stache-general <i class="fa fa-lock" aria-hidden="true"></i></a> Slack channel.
         </p>
       </li>
     </ul>

--- a/src/app/support/why-stache/index.html
+++ b/src/app/support/why-stache/index.html
@@ -41,8 +41,8 @@ Then, that's the time you need to invest in creating good documentation. Good do
 
 ### Blackbaud only:
 
-- Pervasive search (inclusion in the [global Stache search <i class="fa fa-lock" aria-hidden="true" title="Blackbaud users only"></i>](https://docs.blackbaud.com))
-- Options for who can view your site (Blackbaud users only with Blackbaud ID or public)
+- Pervasive search (inclusion in the [global Stache search <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i>](https://docs.blackbaud.com))
+- Options for who can view your site (Blackbaud staff only with Blackbaud ID or public)
 - Hosted in Azure
 - Quick SPA and VSTS repo creation with the SKY UX App Management Portal
 - Automatically configured deployments
@@ -103,7 +103,7 @@ Best of all ... Stache is in-development for you. This means we are here to adap
     Question #3: Do you primarily need to share files?
   </h3>
   <p>
-    If the primary purpose of your content is to only share files, like Microsoft Word documents, then don't create a Stache site. If you're a Blackbaud user, we recommend you use our Office365 tools (SharePoint) to set up a document library instead.
+    If the primary purpose of your content is to only share files, like Microsoft Word documents, then don't create a Stache site. If you're a Blackbaud staff, we recommend you use our Office365 tools (SharePoint) to set up a document library instead.
   </p>
 
 </stache>


### PR DESCRIPTION
Based on feedback:
- `Content` is now `Components`
- `Blackbaud users` is now `Blackbaud staff`(plural)  or `Blackbaud staff member` (singular)
- Small edit to getting started to be more clear about Authentication