### PR TITLE
Updated navTitle for Components page

### DIFF
--- a/src/app/content/demo-content.component.html
+++ b/src/app/content/demo-content.component.html
@@ -1,6 +1,7 @@
 <stache
   showEditButton="false"
   pageTitle="Components"
+  navTitle="Components"
   layout="container">
 
   <stache-page-summary>


### PR DESCRIPTION
I missed this change when we changed the name. Can't pull from the folder now, so we need to set it on the page.