### PR TITLE
Update nav-style-override.html

### DIFF
--- a/src/stache/includes/nav-style-override.html
+++ b/src/stache/includes/nav-style-override.html
@@ -4,7 +4,7 @@
   </stache-tutorial-step-heading>
   <stache-tutorial-step-body>
     <sky-alert alertType="info">
-      Blackbaud Staff <i class="fa fa-lock" aria-hidden="true"></i> should use the Omnibar instead of the <stache-code>app-nav</stache-code> component. To learn how to set up top-level navigation with the Omnibar, see step 4 of the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">Create a Blackbaud Stache SPA <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a> tutorial.
+      Blackbaud Staff <i class="fa fa-lock" aria-hidden="true"></i> should use the Omnibar instead of the <stache-code>app-nav</stache-code> component. To learn how to set up top-level navigation with the Omnibar, see step 4 of the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache#set-up-the-omnibar-navigation">Create a Blackbaud Stache SPA <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a> tutorial.
     </sky-alert>
     <ol>
       <li>

--- a/src/stache/includes/nav-style-override.html
+++ b/src/stache/includes/nav-style-override.html
@@ -3,6 +3,9 @@
     Update app-nav component
   </stache-tutorial-step-heading>
   <stache-tutorial-step-body>
+    <sky-alert alertType="info">
+      For <strong>internal Blackbaud SPAs</strong>, we recommend the omnibar instead of the <stache-code>app-nav</stache-code> component. However, it is for Blackbaud staff use only. To learn how to set up top-level navigation with the omnibar, see step 4 of the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">Create a Blackbaud Stache SPA <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a> tutorial.
+    </sky-alert>
     <ol>
       <li>
         Open the

--- a/src/stache/includes/nav-style-override.html
+++ b/src/stache/includes/nav-style-override.html
@@ -4,7 +4,7 @@
   </stache-tutorial-step-heading>
   <stache-tutorial-step-body>
     <sky-alert alertType="info">
-      For <strong>internal Blackbaud SPAs</strong>, we recommend the omnibar instead of the <stache-code>app-nav</stache-code> component. However, it is for Blackbaud staff use only. To learn how to set up top-level navigation with the omnibar, see step 4 of the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">Create a Blackbaud Stache SPA <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a> tutorial.
+      Blackbaud Staff <i class="fa fa-lock" aria-hidden="true"></i> should use the Omnibar instead of the <stache-code>app-nav</stache-code> component. To learn how to set up top-level navigation with the Omnibar, see step 4 of the <a href="https://docs.blackbaud.com/stache-internal/new-bb-stache">Create a Blackbaud Stache SPA <i class="fa fa-lock" aria-hidden="true" title="Blackbaud staff only"></i></a> tutorial.
     </sky-alert>
     <ol>
       <li>


### PR DESCRIPTION
Add warning similar to what's on the https://developer.blackbaud.com/stache/learn/basics page since app-nav is not used for internal Blackbaud sites that leverage the omnibar.