### PR TITLE
fix code-block supported languages view

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -73,29 +73,3 @@
   padding-top: 50px;
   padding-bottom: 50px;
 }
-
-
-.sky-definition-list {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  max-height: 1300px;
-  list-style: none;
-
-  @media (min-width: 992px) and (max-width: 1350px) {
-    max-height: 1900px;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    list-style: none;
-  }
-
-  @media (max-width: 991px) {
-    max-height: none;
-  }
-}
-
-.sky-definition-list-content {
-  padding-right: 40px;
-}
-

--- a/src/app/content/code-block/language-type-list.component.html
+++ b/src/app/content/code-block/language-type-list.component.html
@@ -1,6 +1,6 @@
 <div class="language-list">
   <span>
-    <sky-definition-list labelWidth="175px" *ngFor="let column of languageColumns">
+    <sky-definition-list labelWidth="150px" *ngFor="let column of languageColumns">
       <sky-definition-list-content *ngFor="let item of column">
         <sky-definition-list-label>
           {{item.label}}

--- a/src/app/content/code-block/language-type-list.component.html
+++ b/src/app/content/code-block/language-type-list.component.html
@@ -1,6 +1,6 @@
 <div class="language-list">
   <span>
-    <sky-definition-list labelWidth="150px" *ngFor="let column of languageColumns">
+    <sky-definition-list labelWidth="130px" *ngFor="let column of languageColumns">
       <sky-definition-list-content *ngFor="let item of column">
         <sky-definition-list-label>
           {{item.label}}

--- a/src/app/content/code-block/language-type-list.component.html
+++ b/src/app/content/code-block/language-type-list.component.html
@@ -1,13 +1,14 @@
 <div class="language-list">
-  <sky-definition-list  labelWidth="175px">
-    <sky-definition-list-content
-      *ngFor="let item of languageType">
-      <sky-definition-list-label>
-        {{item.label}}
-      </sky-definition-list-label>
-      <sky-definition-list-value>
-        <stache-code>{{item.value}}</stache-code>
-      </sky-definition-list-value>
-    </sky-definition-list-content>
-  </sky-definition-list>
+  <span>
+    <sky-definition-list labelWidth="175px" *ngFor="let column of languageColumns">
+      <sky-definition-list-content *ngFor="let item of column">
+        <sky-definition-list-label>
+          {{item.label}}
+        </sky-definition-list-label>
+        <sky-definition-list-value>
+          <stache-code>{{item.value}}</stache-code>
+        </sky-definition-list-value>
+      </sky-definition-list-content>
+    </sky-definition-list>
+  </span>
 </div>

--- a/src/app/content/code-block/language-type-list.component.scss
+++ b/src/app/content/code-block/language-type-list.component.scss
@@ -2,6 +2,7 @@
 .sky-definition-list {
   display: inline-flex;
   flex-direction: column;
+  margin-bottom: 0px !important;
 }
 
 ::ng-deep

--- a/src/app/content/code-block/language-type-list.component.scss
+++ b/src/app/content/code-block/language-type-list.component.scss
@@ -1,11 +1,11 @@
 ::ng-deep
 .sky-definition-list {
   display: inline-flex;
-  flex-direction: column;
+  flex-flow: column wrap;
   margin-bottom: 0px !important;
 }
 
 ::ng-deep
 .sky-definition-list-content {
-  padding-right: 40px;
+  width: 400px;
 }

--- a/src/app/content/code-block/language-type-list.component.scss
+++ b/src/app/content/code-block/language-type-list.component.scss
@@ -2,6 +2,7 @@
 .sky-definition-list {
   display: inline-flex;
   flex-flow: column wrap;
+  margin-right: 0px !important;
   margin-bottom: 0px !important;
 }
 

--- a/src/app/content/code-block/language-type-list.component.scss
+++ b/src/app/content/code-block/language-type-list.component.scss
@@ -1,0 +1,10 @@
+::ng-deep
+.sky-definition-list {
+  display: inline-flex;
+  flex-direction: column;
+}
+
+::ng-deep
+.sky-definition-list-content {
+  padding-right: 40px;
+}

--- a/src/app/content/code-block/language-type-list.component.scss
+++ b/src/app/content/code-block/language-type-list.component.scss
@@ -7,5 +7,5 @@
 
 ::ng-deep
 .sky-definition-list-content {
-  width: 400px;
+  width: 300px;
 }

--- a/src/app/content/code-block/language-type-list.component.ts
+++ b/src/app/content/code-block/language-type-list.component.ts
@@ -612,4 +612,16 @@ export class LanguageTypeListComponent {
       value: 'yam'
     }
   ];
+
+  public languageColumns: any[] = [];
+
+  constructor() {
+    const columnCount = 2;
+    const columnLength = Math.ceil(this.languageType.length / columnCount);
+    let columnStart = 0;
+    for (let i = 0; i < columnCount; i ++) {
+      this.languageColumns.push(this.languageType.slice(columnStart, columnStart + columnLength));
+      columnStart = columnStart + columnLength;
+    }
+  }
 }


### PR DESCRIPTION
Fixed an issues @blackbaud-johnly was seeing where when he resized the code-block docs some of the supported languages were being hidden behind the table of contents. 