### PR TITLE
Update installation commands to include --save exact

### DIFF
--- a/src/app/components/clipboard/index.html
+++ b/src/app/components/clipboard/index.html
@@ -78,7 +78,7 @@
         To install the package as part of your SPA's dependencies run the following command from your SPA's root directory.
       </p>
       <sky-code-block>
-        npm install @blackbaud/skyux-lib-clipboard --save
+        npm install @blackbaud/skyux-lib-clipboard --save --save-exact
       </sky-code-block>
     </li>
     <li>

--- a/src/app/components/code-block/index.html
+++ b/src/app/components/code-block/index.html
@@ -65,11 +65,11 @@
         To install the package and plugin as part of your SPA's dependencies run the following command from your SPA's root directory.
       </p>
       <sky-code-block>
-        npm install @blackbaud/skyux-lib-code-block --save
+        npm install @blackbaud/skyux-lib-code-block --save --save-exact
       </sky-code-block>
 
       <sky-code-block>
-        npm install @blackbaud/skyux-builder-plugin-code-block --save
+        npm install @blackbaud/skyux-builder-plugin-code-block --save --save-exact
       </sky-code-block>
     </li>
     <li>

--- a/src/app/components/code/index.html
+++ b/src/app/components/code/index.html
@@ -41,11 +41,11 @@
             To install the package and plugin as part of your SPA's dependencies run the following command from your SPA's root directory.
           </p>
           <sky-code-block>
-            npm install @blackbaud/skyux-lib-code-block --save
+            npm install @blackbaud/skyux-lib-code-block --save --save-exact
           </sky-code-block>
 
           <sky-code-block>
-            npm install @blackbaud/skyux-builder-plugin-code-block --save
+            npm install @blackbaud/skyux-builder-plugin-code-block --save --save-exact
           </sky-code-block>
         </li>
         <li>

--- a/src/app/components/grid/index.html
+++ b/src/app/components/grid/index.html
@@ -1,5 +1,6 @@
 <stache
-  pageTitle="Grid">
+  pageTitle="Grid"
+  showTableOfContents="true">
 
   <stache-page-summary>
     <p>

--- a/src/app/components/hero/index.html
+++ b/src/app/components/hero/index.html
@@ -65,7 +65,7 @@
             To install the package and plugin as part of your SPA's dependencies run the following command from your SPA's root directory.
           </p>
           <sky-code-block>
-            npm install @blackbaud/skyux-lib-media --save
+            npm install @blackbaud/skyux-lib-media --save --save-exact
           </sky-code-block>
         </li>
         <li>

--- a/src/app/components/image/index.html
+++ b/src/app/components/image/index.html
@@ -73,7 +73,7 @@
           To install the package and plugin as part of your SPA's dependencies run the following command from your SPA's root directory.
         </p>
         <sky-code-block>
-          npm install @blackbaud/skyux-lib-media --save
+          npm install @blackbaud/skyux-lib-media --save --save-exact
         </sky-code-block>
       </li>
       <li>

--- a/src/app/components/video/index.html
+++ b/src/app/components/video/index.html
@@ -74,7 +74,7 @@
             To install the package and plugin as part of your SPA's dependencies run the following command from your SPA's root directory.
           </p>
         <sky-code-block>
-          npm install @blackbaud/skyux-lib-media --save
+          npm install @blackbaud/skyux-lib-media --save --save-exact
         </sky-code-block>
       </li>
       <li>


### PR DESCRIPTION
I meant to add `--save exact` to the installation commands after we created SKY UX versions of the code block and copy to clipboard docs but never got around to it. Ben L. asked about this for copy to clipboard, so I went ahead and cleaned up all the install commands and also fixed the grid component to include the TOC for consistency with the rest of the components.